### PR TITLE
Expose attribute and relationship exclusion as ER diagram options

### DIFF
--- a/docs/verbs/mermaid-er-diagram-from-csharp.md
+++ b/docs/verbs/mermaid-er-diagram-from-csharp.md
@@ -13,11 +13,12 @@ The verb 'mermaid-er-diagram-from-csharp' uses the following options.
 
 |Option|Alias|Type|Description|
 |---|---|---|---|
-|--exclude-all-attributes||true/false|Should all attributes be excluded from the diagram?|
-|--exclude-all-relationships||true/false|Should all relationships be excluded from the diagram?|
+|--attribute-type-exclusion||none / foreignkeys / all|What kind of attributes should be excluded from the diagram?|
+|--exclude-all-attributes||true/false|Deprecated, use 'attribute-type-exclusion instead.|
+|--exclude-all-relationships||true/false|Deprecated, use 'relationship-type-exclusion instead.|
 |--exclude-attribute-comments||true/false|Should attributes comments be excluded from the diagram?|
 |--exclude-attribute-keytypes||true/false|Should attributes key types be excluded from the diagram?|
-|--exclude-foreignkey-attributes||true/false|Should foreign key attributes be excluded from the diagram?|
+|--exclude-foreignkey-attributes||true/false|Deprecated, use 'attribute-type-exclusion instead.|
 |--exclude-propertynames||List of string|A list of regular expressions for property names to exclude from each type.|
 |--exclude-typenames||List of string|A list of regular expressions for type names to exclude.|
 |--include-namespaces||List of string|A list of regular expressions for namespaces to include.|
@@ -27,6 +28,7 @@ The verb 'mermaid-er-diagram-from-csharp' uses the following options.
 |--name-replace-to||string|The string to replace with in all class/entity names.|
 |--options-file|-f|string|Read options from this file.|
 |--output-file|-o|string|Write the generated representation to this file.|
+|--relationship-type-exclusion||none / all|What kind of relationships should be excluded from the diagram?|
 |--replace-token-in-output-file||string|Replace this token in the output file with the generated representation instead of just writing the generated representation to the specified output file.|
 |--tree-shaking-roots||List of string|A list of regular expressions for types to keep as roots when tree shaking the resulting diagram.|
 
@@ -39,11 +41,9 @@ Here is a template for an options file for 'mermaid-er-diagram-from-csharp'.
 #
 # dry-gen options for verb 'mermaid-er-diagram-from-csharp'
 #
-#exclude-all-attributes: true|false
-#exclude-all-relationships: true|false
+#attribute-type-exclusion: none | foreignkeys | all
 #exclude-attribute-comments: true|false
 #exclude-attribute-keytypes: true|false
-#exclude-foreignkey-attributes: true|false
 #exclude-propertynames: # List of string
 #- 
 #exclude-typenames: # List of string
@@ -56,6 +56,7 @@ Here is a template for an options file for 'mermaid-er-diagram-from-csharp'.
 #name-replace-from: string
 #name-replace-to: string
 #output-file: string
+#relationship-type-exclusion: none | all
 #replace-token-in-output-file: string
 #tree-shaking-roots: # List of string
 #- 

--- a/docs/verbs/mermaid-er-diagram-from-efcore.md
+++ b/docs/verbs/mermaid-er-diagram-from-efcore.md
@@ -13,11 +13,12 @@ The verb 'mermaid-er-diagram-from-efcore' uses the following options.
 
 |Option|Alias|Type|Description|
 |---|---|---|---|
-|--exclude-all-attributes||true/false|Should all attributes be excluded from the diagram?|
-|--exclude-all-relationships||true/false|Should all relationships be excluded from the diagram?|
+|--attribute-type-exclusion||none / foreignkeys / all|What kind of attributes should be excluded from the diagram?|
+|--exclude-all-attributes||true/false|Deprecated, use 'attribute-type-exclusion instead.|
+|--exclude-all-relationships||true/false|Deprecated, use 'relationship-type-exclusion instead.|
 |--exclude-attribute-comments||true/false|Should attributes comments be excluded from the diagram?|
 |--exclude-attribute-keytypes||true/false|Should attributes key types be excluded from the diagram?|
-|--exclude-foreignkey-attributes||true/false|Should foreign key attributes be excluded from the diagram?|
+|--exclude-foreignkey-attributes||true/false|Deprecated, use 'attribute-type-exclusion instead.|
 |--exclude-propertynames||List of string|A list of regular expressions for property names to exclude from each type.|
 |--exclude-typenames||List of string|A list of regular expressions for type names to exclude.|
 |--include-namespaces||List of string|A list of regular expressions for namespaces to include.|
@@ -27,6 +28,7 @@ The verb 'mermaid-er-diagram-from-efcore' uses the following options.
 |--name-replace-to||string|The string to replace with in all class/entity names.|
 |--options-file|-f|string|Read options from this file.|
 |--output-file|-o|string|Write the generated representation to this file.|
+|--relationship-type-exclusion||none / all|What kind of relationships should be excluded from the diagram?|
 |--replace-token-in-output-file||string|Replace this token in the output file with the generated representation instead of just writing the generated representation to the specified output file.|
 |--tree-shaking-roots||List of string|A list of regular expressions for types to keep as roots when tree shaking the resulting diagram.|
 
@@ -39,11 +41,9 @@ Here is a template for an options file for 'mermaid-er-diagram-from-efcore'.
 #
 # dry-gen options for verb 'mermaid-er-diagram-from-efcore'
 #
-#exclude-all-attributes: true|false
-#exclude-all-relationships: true|false
+#attribute-type-exclusion: none | foreignkeys | all
 #exclude-attribute-comments: true|false
 #exclude-attribute-keytypes: true|false
-#exclude-foreignkey-attributes: true|false
 #exclude-propertynames: # List of string
 #- 
 #exclude-typenames: # List of string
@@ -56,6 +56,7 @@ Here is a template for an options file for 'mermaid-er-diagram-from-efcore'.
 #name-replace-from: string
 #name-replace-to: string
 #output-file: string
+#relationship-type-exclusion: none | all
 #replace-token-in-output-file: string
 #tree-shaking-roots: # List of string
 #- 

--- a/src/DryGen.MermaidFromCSharp/ErDiagram/ErDiagramGenerator.cs
+++ b/src/DryGen.MermaidFromCSharp/ErDiagram/ErDiagramGenerator.cs
@@ -15,9 +15,9 @@ namespace DryGen.MermaidFromCSharp.ErDiagram
 
         public ErDiagramGenerator(IMermaidErDiagramFromCSharpOptions options) : this(
             options.StructureBuilder,
-            options.AttributeTypeExclusion,
+            options.AttributeTypeExclusion ?? ErDiagramAttributeTypeExclusion.None,
             options.AttributeDetailExclusions,
-            options.RelationshipTypeExclusion
+            options.RelationshipTypeExclusion ?? ErDiagramRelationshipTypeExclusion.None
             )
         { }
 

--- a/src/DryGen.MermaidFromCSharp/ErDiagram/IMermaidErDiagramFromCSharpOptions.cs
+++ b/src/DryGen.MermaidFromCSharp/ErDiagram/IMermaidErDiagramFromCSharpOptions.cs
@@ -2,9 +2,9 @@
 {
     public interface IMermaidErDiagramFromCSharpOptions : IMermaidDiagramOptions
     {
-        ErDiagramAttributeTypeExclusion AttributeTypeExclusion { get; }
+        ErDiagramAttributeTypeExclusion? AttributeTypeExclusion { get; }
         ErDiagramAttributeDetailExclusions AttributeDetailExclusions { get; }
-        ErDiagramRelationshipTypeExclusion RelationshipTypeExclusion { get; }
+        ErDiagramRelationshipTypeExclusion? RelationshipTypeExclusion { get; }
         IErDiagramStructureBuilder StructureBuilder { get; }
     }
 }

--- a/src/DryGen/Constants.cs
+++ b/src/DryGen/Constants.cs
@@ -24,7 +24,10 @@
             public const string ExcludeAllAttributesOption = "exclude-all-attributes";
             public const string ExcludeForeignkeyAttributesOption = "exclude-foreignkey-attributes";
             public const string AttributeTypeExclusionOption = "attribute-type-exclusion";
+            public const string ExcludeAllRelationshipsOption = "exclude-all-relationships";
+            public const string RelationshipTypeExclusionOption = "relationship-type-exclusion";
             public const string ReplacedByAttributeTypeExclusionHelpText = DeprecatedNotice + ", use '" + AttributeTypeExclusionOption + " instead.";
+            public const string ReplacedByRelationshipTypeExclusionHelpText = DeprecatedNotice + ", use '" + RelationshipTypeExclusionOption + " instead.";
         }
 
         public static class MermaidErDiagramFromEfCore

--- a/src/DryGen/Constants.cs
+++ b/src/DryGen/Constants.cs
@@ -2,6 +2,7 @@
 {
     public static class Constants
     {
+        public const string DeprecatedNotice = "Deprecated";
         public const string InputFileOption = "input-file";
         public const string OutputFileOption = "output-file";
         public const string OptionsFileOption = "options-file";
@@ -20,6 +21,10 @@
         public static class MermaidErDiagramFromCsharp
         {
             public const string Verb = "mermaid-er-diagram-from-csharp";
+            public const string ExcludeAllAttributesOption = "exclude-all-attributes";
+            public const string ExcludeForeignkeyAttributesOption = "exclude-foreignkey-attributes";
+            public const string AttributeTypeExclusionOption = "attribute-type-exclusion";
+            public const string ReplacedByAttributeTypeExclusionHelpText = DeprecatedNotice + ", use '" + AttributeTypeExclusionOption + " instead.";
         }
 
         public static class MermaidErDiagramFromEfCore

--- a/src/DryGen/Extensions.cs
+++ b/src/DryGen/Extensions.cs
@@ -35,16 +35,8 @@ namespace DryGen
                 {
                     continue;
                 }
-                var optionMetadata = new OptionMetadata();
-                optionMetadata.LongName = optionAttribute.ConstructorArguments.Single(x => x.ArgumentType == typeof(string)).Value?.ToString()?.Replace("\"", string.Empty) ?? string.Empty;
-                optionMetadata.LongName = $"--{optionMetadata.LongName}";
-                optionMetadata.ShortName = optionAttribute.ConstructorArguments.SingleOrDefault(x => x.ArgumentType == typeof(char)).Value?.ToString()?.Replace("\"", string.Empty) ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(optionMetadata.ShortName))
-                {
-                    optionMetadata.ShortName = $"-{optionMetadata.ShortName}";
-                }
-                optionMetadata.Description = optionAttribute.NamedArguments.Single(x => x.MemberName == nameof(OptionAttribute.HelpText)).TypedValue.ToString()?.Replace("\"", string.Empty) ?? string.Empty;
-                optionMetadata.Type = propery.PropertyType.GeneratePropertyTypeInfo(asYamlComment : false);
+                var optionMetadata = new OptionMetadata(optionAttribute);
+                optionMetadata.Type = propery.PropertyType.GeneratePropertyTypeInfo(asYamlComment: false);
                 optionList.Add(optionMetadata);
             }
             return optionList.OrderBy(x => x.LongName).ToArray();

--- a/src/DryGen/Generator.cs
+++ b/src/DryGen/Generator.cs
@@ -156,6 +156,7 @@ namespace DryGen
                 {
                     WarnIfDeprecatedIsUsed(options.ExcludeAllAttributes.HasValue, Constants.MermaidErDiagramFromCsharp.ExcludeAllAttributesOption, Constants.MermaidErDiagramFromCsharp.AttributeTypeExclusionOption);
                     WarnIfDeprecatedIsUsed(options.ExcludeForeignkeyAttributes.HasValue, Constants.MermaidErDiagramFromCsharp.ExcludeForeignkeyAttributesOption, Constants.MermaidErDiagramFromCsharp.AttributeTypeExclusionOption);
+                    WarnIfDeprecatedIsUsed(options.ExcludeAllRelationships.HasValue, Constants.MermaidErDiagramFromCsharp.ExcludeAllRelationshipsOption, Constants.MermaidErDiagramFromCsharp.RelationshipTypeExclusionOption);
                 }
                 return GenerateMermaidDiagramFromCSharp(options, diagramGenerator);
             });

--- a/src/DryGen/Generator.cs
+++ b/src/DryGen/Generator.cs
@@ -152,8 +152,21 @@ namespace DryGen
             return ExecuteWithOptionsFromFileExceptionHandlingAndHelpDisplay(options, args, "Mermaid ER diagram", options =>
             {
                 var diagramGenerator = new ErDiagramGenerator(options);
+                if (!string.IsNullOrEmpty(options.OutputFile))
+                {
+                    WarnIfDeprecatedIsUsed(options.ExcludeAllAttributes.HasValue, Constants.MermaidErDiagramFromCsharp.ExcludeAllAttributesOption, Constants.MermaidErDiagramFromCsharp.AttributeTypeExclusionOption);
+                    WarnIfDeprecatedIsUsed(options.ExcludeForeignkeyAttributes.HasValue, Constants.MermaidErDiagramFromCsharp.ExcludeForeignkeyAttributesOption, Constants.MermaidErDiagramFromCsharp.AttributeTypeExclusionOption);
+                }
                 return GenerateMermaidDiagramFromCSharp(options, diagramGenerator);
             });
+        }
+
+        private void WarnIfDeprecatedIsUsed(bool isDeprecatedOptionUsed, string deprecatedOption, string replacedByOption)
+        {
+            if (isDeprecatedOptionUsed)
+            {
+                outWriter.WriteLine($"Warning! The option '{deprecatedOption}' is deprecated. Use '{replacedByOption}' instead.");
+            }
         }
 
         private int GenerateMermaidErDiagramFromEfCore(MermaidErDiagramFromEfCoreOptions options, string[] args)

--- a/src/DryGen/OptionMetadata.cs
+++ b/src/DryGen/OptionMetadata.cs
@@ -1,12 +1,26 @@
 ﻿using CommandLine;
+using System.Linq;
+using System.Reflection;
 
 namespace DryGen
 {
     public class OptionMetadata
     {
-        public string? LongName { get; set; }
-        public string? ShortName { get; set; }
-        public string? Description { get; set; }
+        public OptionMetadata(CustomAttributeData optionAttribute)
+        {
+            LongName = optionAttribute.ConstructorArguments.Single(x => x.ArgumentType == typeof(string)).Value?.ToString()?.Replace("\"", string.Empty) ?? string.Empty;
+            LongName = $"--{LongName}";
+            ShortName = optionAttribute.ConstructorArguments.SingleOrDefault(x => x.ArgumentType == typeof(char)).Value?.ToString()?.Replace("\"", string.Empty) ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(ShortName))
+            {
+                ShortName = $"-{ShortName}";
+            }
+            Description = optionAttribute.NamedArguments.Single(x => x.MemberName == nameof(OptionAttribute.HelpText)).TypedValue.ToString()?.Replace("\"", string.Empty) ?? string.Empty;
+        }
+
+        public string? LongName { get; private set; }
+        public string? ShortName { get; private set; }
+        public string? Description { get; private set; }
         public string? Type { get; set; }
     }
 }

--- a/src/DryGen/Options/MermaidErDiagramFromCSharpBaseOptions.cs
+++ b/src/DryGen/Options/MermaidErDiagramFromCSharpBaseOptions.cs
@@ -6,8 +6,8 @@ namespace DryGen.Options
 {
     public abstract class MermaidErDiagramFromCSharpBaseOptions : MermaidFromCSharpBaseOptions, IMermaidErDiagramFromCSharpOptions
     {
-        [YamlMember(Alias = "exclude-all-attributes", ApplyNamingConventions = false)]
-        [Option("exclude-all-attributes", HelpText = "Should all attributes be excluded from the diagram?")]
+        [YamlMember(Alias = Constants.MermaidErDiagramFromCsharp.ExcludeAllAttributesOption, ApplyNamingConventions = false)]
+        [Option(Constants.MermaidErDiagramFromCsharp.ExcludeAllAttributesOption, HelpText = Constants.MermaidErDiagramFromCsharp.ReplacedByAttributeTypeExclusionHelpText)]
         public bool? ExcludeAllAttributes { get; set; }
 
         [YamlMember(Alias = "exclude-attribute-keytypes", ApplyNamingConventions = false)]
@@ -18,18 +18,24 @@ namespace DryGen.Options
         [Option("exclude-attribute-comments", HelpText = "Should attributes comments be excluded from the diagram?")]
         public bool? ExcludeAttributeComments { get; set; }
 
-        [YamlMember(Alias = "exclude-foreignkey-attributes", ApplyNamingConventions = false)]
-        [Option("exclude-foreignkey-attributes", HelpText = "Should foreign key attributes be excluded from the diagram?")]
+        [YamlMember(Alias = Constants.MermaidErDiagramFromCsharp.ExcludeForeignkeyAttributesOption, ApplyNamingConventions = false)]
+        [Option(Constants.MermaidErDiagramFromCsharp.ExcludeForeignkeyAttributesOption, HelpText = Constants.MermaidErDiagramFromCsharp.ReplacedByAttributeTypeExclusionHelpText)]
         public bool? ExcludeForeignkeyAttributes { get; set; }
 
         [YamlMember(Alias = "exclude-all-relationships", ApplyNamingConventions = false)]
         [Option("exclude-all-relationships", HelpText = "Should all relationships be excluded from the diagram?")]
         public bool? ExcludeAllRelationships { get; set; }
 
-        public ErDiagramAttributeTypeExclusion AttributeTypeExclusion
+        [YamlMember(Alias = Constants.MermaidErDiagramFromCsharp.AttributeTypeExclusionOption, ApplyNamingConventions = false)]
+        [Option(Constants.MermaidErDiagramFromCsharp.AttributeTypeExclusionOption, HelpText = "What kind of attributes should be excluded from the diagram?")]
+        public ErDiagramAttributeTypeExclusion? AttributeTypeExclusion
         {
             get
             {
+                if (attributeTypeExclusion.HasValue)
+                {
+                    return attributeTypeExclusion;
+                }
                 if (ExcludeAllAttributes ?? default)
                 {
                     return ErDiagramAttributeTypeExclusion.All;
@@ -40,6 +46,7 @@ namespace DryGen.Options
                 }
                 return ErDiagramAttributeTypeExclusion.None;
             }
+            set { attributeTypeExclusion = value; }
         }
 
         public ErDiagramAttributeDetailExclusions AttributeDetailExclusions
@@ -59,7 +66,7 @@ namespace DryGen.Options
             }
         }
 
-        public ErDiagramRelationshipTypeExclusion RelationshipTypeExclusion =>
+        public ErDiagramRelationshipTypeExclusion? RelationshipTypeExclusion =>
             ExcludeAllRelationships ?? default ? ErDiagramRelationshipTypeExclusion.All : ErDiagramRelationshipTypeExclusion.None;
 
         public IErDiagramStructureBuilder StructureBuilder { get; private set; }
@@ -68,5 +75,7 @@ namespace DryGen.Options
         {
             StructureBuilder = structureBuilder;
         }
+
+        private ErDiagramAttributeTypeExclusion? attributeTypeExclusion;
     }
 }

--- a/src/DryGen/Options/MermaidErDiagramFromCSharpBaseOptions.cs
+++ b/src/DryGen/Options/MermaidErDiagramFromCSharpBaseOptions.cs
@@ -22,8 +22,8 @@ namespace DryGen.Options
         [Option(Constants.MermaidErDiagramFromCsharp.ExcludeForeignkeyAttributesOption, HelpText = Constants.MermaidErDiagramFromCsharp.ReplacedByAttributeTypeExclusionHelpText)]
         public bool? ExcludeForeignkeyAttributes { get; set; }
 
-        [YamlMember(Alias = "exclude-all-relationships", ApplyNamingConventions = false)]
-        [Option("exclude-all-relationships", HelpText = "Should all relationships be excluded from the diagram?")]
+        [YamlMember(Alias = Constants.MermaidErDiagramFromCsharp.ExcludeAllRelationshipsOption, ApplyNamingConventions = false)]
+        [Option(Constants.MermaidErDiagramFromCsharp.ExcludeAllRelationshipsOption, HelpText = Constants.MermaidErDiagramFromCsharp.ReplacedByRelationshipTypeExclusionHelpText)]
         public bool? ExcludeAllRelationships { get; set; }
 
         [YamlMember(Alias = Constants.MermaidErDiagramFromCsharp.AttributeTypeExclusionOption, ApplyNamingConventions = false)]
@@ -49,6 +49,21 @@ namespace DryGen.Options
             set { attributeTypeExclusion = value; }
         }
 
+        [YamlMember(Alias = Constants.MermaidErDiagramFromCsharp.RelationshipTypeExclusionOption, ApplyNamingConventions = false)]
+        [Option(Constants.MermaidErDiagramFromCsharp.RelationshipTypeExclusionOption, HelpText = "What kind of relationships should be excluded from the diagram?")]
+        public ErDiagramRelationshipTypeExclusion? RelationshipTypeExclusion
+        {
+            get
+            {
+                if (relationshipTypeExclusion.HasValue)
+                {
+                    return relationshipTypeExclusion;
+                }
+                return ExcludeAllRelationships ?? default ? ErDiagramRelationshipTypeExclusion.All : ErDiagramRelationshipTypeExclusion.None;
+            }
+            set { relationshipTypeExclusion = value; }
+        }
+
         public ErDiagramAttributeDetailExclusions AttributeDetailExclusions
         {
             get
@@ -66,9 +81,6 @@ namespace DryGen.Options
             }
         }
 
-        public ErDiagramRelationshipTypeExclusion? RelationshipTypeExclusion =>
-            ExcludeAllRelationships ?? default ? ErDiagramRelationshipTypeExclusion.All : ErDiagramRelationshipTypeExclusion.None;
-
         public IErDiagramStructureBuilder StructureBuilder { get; private set; }
 
         protected MermaidErDiagramFromCSharpBaseOptions(IErDiagramStructureBuilder structureBuilder)
@@ -77,5 +89,6 @@ namespace DryGen.Options
         }
 
         private ErDiagramAttributeTypeExclusion? attributeTypeExclusion;
+        private ErDiagramRelationshipTypeExclusion? relationshipTypeExclusion;
     }
 }

--- a/src/DryGen/OptionsFromCommandlineGenerator.cs
+++ b/src/DryGen/OptionsFromCommandlineGenerator.cs
@@ -1,4 +1,5 @@
-﻿using DryGen.Options;
+﻿using CommandLine;
+using DryGen.Options;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,6 +38,16 @@ namespace DryGen
                     ? yamlMemberAttribute?.NamedArguments.Single(x => x.MemberName == nameof(YamlMemberAttribute.Alias)).TypedValue.ToString().Replace("\"", string.Empty)
                     : null;
                 if (string.IsNullOrEmpty(alias))
+                {
+                    continue;
+                }
+                var optionAttribute = propery.CustomAttributes.SingleOrDefault(x => x.AttributeType == typeof(OptionAttribute));
+                if (optionAttribute == null)
+                {
+                    continue;
+                }
+                var optionMetadata = new OptionMetadata(optionAttribute);
+                if (optionMetadata.Description?.StartsWith(Constants.DeprecatedNotice) == true)
                 {
                     continue;
                 }

--- a/src/develop/DryGen.UTests/Features/GenerateOptions.feature
+++ b/src/develop/DryGen.UTests/Features/GenerateOptions.feature
@@ -110,7 +110,6 @@ Scenario: Should generate options for verb mermaid-er-diagram-from-csharp
 		# dry-gen options for verb 'mermaid-er-diagram-from-csharp'
 		#
 		#attribute-type-exclusion: none | foreignkeys | all
-		#exclude-all-relationships: true|false
 		#exclude-attribute-comments: true|false
 		#exclude-attribute-keytypes: true|false
 		#exclude-propertynames: # List of string
@@ -125,6 +124,7 @@ Scenario: Should generate options for verb mermaid-er-diagram-from-csharp
 		#name-replace-from: string
 		#name-replace-to: string
 		#output-file: string
+		#relationship-type-exclusion: none | all
 		#replace-token-in-output-file: string
 		#tree-shaking-roots: # List of string
 		#- 
@@ -143,7 +143,6 @@ Scenario: Should generate options for verb mermaid-er-diagram-from-efcore
 		# dry-gen options for verb 'mermaid-er-diagram-from-efcore'
 		#
 		#attribute-type-exclusion: none | foreignkeys | all
-		#exclude-all-relationships: true|false
 		#exclude-attribute-comments: true|false
 		#exclude-attribute-keytypes: true|false
 		#exclude-propertynames: # List of string
@@ -158,6 +157,7 @@ Scenario: Should generate options for verb mermaid-er-diagram-from-efcore
 		#name-replace-from: string
 		#name-replace-to: string
 		#output-file: string
+		#relationship-type-exclusion: none | all
 		#replace-token-in-output-file: string
 		#tree-shaking-roots: # List of string
 		#- 

--- a/src/develop/DryGen.UTests/Features/GenerateOptions.feature
+++ b/src/develop/DryGen.UTests/Features/GenerateOptions.feature
@@ -109,11 +109,10 @@ Scenario: Should generate options for verb mermaid-er-diagram-from-csharp
 		#
 		# dry-gen options for verb 'mermaid-er-diagram-from-csharp'
 		#
-		#exclude-all-attributes: true|false
+		#attribute-type-exclusion: none | foreignkeys | all
 		#exclude-all-relationships: true|false
 		#exclude-attribute-comments: true|false
 		#exclude-attribute-keytypes: true|false
-		#exclude-foreignkey-attributes: true|false
 		#exclude-propertynames: # List of string
 		#- 
 		#exclude-typenames: # List of string
@@ -143,11 +142,10 @@ Scenario: Should generate options for verb mermaid-er-diagram-from-efcore
 		#
 		# dry-gen options for verb 'mermaid-er-diagram-from-efcore'
 		#
-		#exclude-all-attributes: true|false
+		#attribute-type-exclusion: none | foreignkeys | all
 		#exclude-all-relationships: true|false
 		#exclude-attribute-comments: true|false
 		#exclude-attribute-keytypes: true|false
-		#exclude-foreignkey-attributes: true|false
 		#exclude-propertynames: # List of string
 		#- 
 		#exclude-typenames: # List of string

--- a/src/develop/DryGen.UTests/Features/Mermaid/FromCSharpAndEfCore/ErDiagram/CommandLine.feature
+++ b/src/develop/DryGen.UTests/Features/Mermaid/FromCSharpAndEfCore/ErDiagram/CommandLine.feature
@@ -253,6 +253,46 @@ Scenario: Should generate Er diagram with relationships excluded from argument
 		
 		"""
 
+Scenario: Should generate Er diagram with relationships excluded from type exclusion argument
+	Given the Er diagram relationship exclusion 'All'
+	When I call the program with this command line arguments
+		| Arg                            |
+		| mermaid-er-diagram-from-csharp |
+		| --relationship-type-exclusion  |
+		| all                            |
+	Then I should get exit code '0'
+	And I should get this generated representation file
+		"""
+		erDiagram
+			Customer {
+				int PublicProp PK
+				int NullableProp "Null"
+			}
+			Order
+		
+		"""
+
+Scenario: Should generate Er diagram with relationships excluded from type exclusion argument over deprected
+	Given the Er diagram relationship exclusion 'All'
+	When I call the program with this command line arguments
+		| Arg                            |
+		| mermaid-er-diagram-from-csharp |
+		| --relationship-type-exclusion  |
+		| all                            |
+		| --exclude-all-relationships    |
+		| false                          |
+	Then I should get exit code '0'
+	And I should get this generated representation file
+		"""
+		erDiagram
+			Customer {
+				int PublicProp PK
+				int NullableProp "Null"
+			}
+			Order
+		
+		"""
+
 Scenario: Should tree shake Er diagram from argument
 	Given this C# source code compiled to a file
 	# The commandline argument -i <this assembly filename> will be appended to the command line
@@ -302,6 +342,7 @@ Scenario: Show deprecation warning for deprecated options when output file is sp
 	Then I should get exit code '0'
 	And I should find the text "Warning! The option '<Deprecated option>' is deprecated. Use '<Replaced by option>' instead." in console out
 Examples:
-	| Deprecated option             | Replaced by option       | Deprecated option value |
-	| exclude-all-attributes        | attribute-type-exclusion | true                    |
-	| exclude-foreignkey-attributes | attribute-type-exclusion | false                   |
+	| Deprecated option             | Replaced by option          | Deprecated option value |
+	| exclude-all-attributes        | attribute-type-exclusion    | true                    |
+	| exclude-foreignkey-attributes | attribute-type-exclusion    | false                   |
+	| exclude-all-relationships     | relationship-type-exclusion | true                    |

--- a/src/develop/DryGen.UTests/Features/Mermaid/FromCSharpAndEfCore/ErDiagram/CommandLine.feature
+++ b/src/develop/DryGen.UTests/Features/Mermaid/FromCSharpAndEfCore/ErDiagram/CommandLine.feature
@@ -80,6 +80,44 @@ Scenario: Should generate Er diagram with attributes excluded from argument
 		
 		"""
 
+Scenario: Should generate Er diagram with attributes excluded from type exclusion argument
+	When I call the program with this command line arguments
+		| Arg                            |
+		| mermaid-er-diagram-from-csharp |
+		| --attribute-type-exclusion     |
+		| all                            |
+	Then I should get exit code '0'
+	And I should get this generated representation file
+		"""
+		erDiagram
+			Customer
+			Order
+			Customer ||..|| Order : ""
+		
+		"""
+
+Scenario: Should generate Er diagram with attributes excluded from type exclusion argument over deprecated
+	When I call the program with this command line arguments
+		| Arg                            |
+		| mermaid-er-diagram-from-csharp |
+		| --attribute-type-exclusion     |
+		| all                            |
+		| --<Deprecated option>          |
+		| <Deprecated option value>      |
+	Then I should get exit code '0'
+	And I should get this generated representation file
+		"""
+		erDiagram
+			Customer
+			Order
+			Customer ||..|| Order : ""
+		
+		"""
+Examples:
+	| Deprecated option             | Deprecated option value |
+	| exclude-all-attributes        | false                   |
+	| exclude-foreignkey-attributes | false                   |
+
 Scenario: Should generate Er diagram with attribute key type excluded from argument
 	When I call the program with this command line arguments
 		| Arg                            |
@@ -254,3 +292,16 @@ Examples:
 	| Verb                           |
 	| mermaid-er-diagram-from-csharp |
 	| mermaid-er-diagram-from-efcore |
+
+Scenario: Show deprecation warning for deprecated options when output file is specified
+	When I call the program with this command line arguments
+		| Arg                            |
+		| mermaid-er-diagram-from-csharp |
+		| --<Deprecated option>          |
+		| <Deprecated option value>      |
+	Then I should get exit code '0'
+	And I should find the text "Warning! The option '<Deprecated option>' is deprecated. Use '<Replaced by option>' instead." in console out
+Examples:
+	| Deprecated option             | Replaced by option       | Deprecated option value |
+	| exclude-all-attributes        | attribute-type-exclusion | true                    |
+	| exclude-foreignkey-attributes | attribute-type-exclusion | false                   |


### PR DESCRIPTION
Exposed attribute-type-exclusion and relationship-type-exclusion as options and deprecated exclude-all-attributes, exclude-foreignkey-attributes and exclude-all-relationships when generating Mermaid ER diagrams from C# and EF Core