### PR TITLE
Isolated the loading of input assemblies when generating mermaid diagrams from code

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -231,8 +231,7 @@ public partial class Build : NukeBuild
 
     internal Target Docs => _ => _
         .DependsOn(Init)
-        //.DependsOn(Compile)
-        //.DependsOn(Specs)
+        .DependsOn(Compile)
         .Executes(() =>
         {
             DotNetRun(c => c
@@ -240,7 +239,7 @@ public partial class Build : NukeBuild
                 .SetConfiguration(Configuration)
                 .SetFramework("net6.0")
                 .SetApplicationArguments($"--root-directory {RootDirectory}")
-                //.EnableNoBuild()
+                .EnableNoBuild()
                 .SetNoLaunchProfile(true)
                 );
         });

--- a/src/DryGen.Core/Extensions.cs
+++ b/src/DryGen.Core/Extensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;

--- a/src/DryGen/DryGen.csproj
+++ b/src/DryGen/DryGen.csproj
@@ -18,23 +18,15 @@
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
 		<PackageReference Include="YamlDotNet" Version="13.0.2" />
-		<!-- 
-		NB! We need to reference Microsoft.Extensions.Primitives for each supported .Net version here.
-		Otherwise the loading of EF Core assemblies migth fail with an error that Microsoft.Extensions.Primitives v X.0.0.0 can't be loaded.
-		This happens if a DryGen dependency is referencing and loading an older version of Microsoft.Extensions.Primitives,
-		since the .Net runtime can't load two versions of the same assembly.
-		-->
-		<PackageReference Include="Microsoft.Extensions.Primitives" Version="[7.*,8.0)" Condition="'$(TargetFramework)' == 'net7.0'" />
-		<PackageReference Include="Microsoft.Extensions.Primitives" Version="[6.*,7.0)" Condition="'$(TargetFramework)' == 'net6.0'" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\DryGen.Core\DryGen.Core.csproj" />
-		<ProjectReference Include="..\DryGen.MermaidFromDotnetDepsJson\DryGen.MermaidFromDotnetDepsJson.csproj" />
-		<ProjectReference Include="..\DryGen.MermaidFromJsonSchema\DryGen.MermaidFromJsonSchema.csproj" />
 		<ProjectReference Include="..\DryGen.CSharpFromJsonSchema\DryGen.CSharpFromJsonSchema.csproj" />
 		<ProjectReference Include="..\DryGen.MermaidFromCSharp\DryGen.MermaidFromCSharp.csproj" />
+		<ProjectReference Include="..\DryGen.MermaidFromDotnetDepsJson\DryGen.MermaidFromDotnetDepsJson.csproj" />
 		<ProjectReference Include="..\DryGen.MermaidFromEfCore\DryGen.MermaidFromEfCore.csproj" />
+		<ProjectReference Include="..\DryGen.MermaidFromJsonSchema\DryGen.MermaidFromJsonSchema.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/DryGen/InternalAssemblyLoadContext.cs
+++ b/src/DryGen/InternalAssemblyLoadContext.cs
@@ -1,0 +1,44 @@
+﻿using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace DryGen;
+
+internal class InternalAssemblyLoadContext: AssemblyLoadContext
+{
+    private readonly string inputFile;
+    private readonly string inputDirectory;
+
+    internal InternalAssemblyLoadContext(string inputFile)
+    {
+        this.inputFile = inputFile;
+        inputDirectory = Path.GetDirectoryName(inputFile) ?? throw new OptionsException($"Could not determine directory from inputFile '{inputFile}'");
+    }
+
+    internal Assembly Load()
+    {
+        EnterContextualReflection();
+        return LoadFromFile(inputFile);
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        foreach (var extension in new[] { ".dll", ".exe" })
+        {
+            var assemblyFileName = $"{inputDirectory}{Path.DirectorySeparatorChar}{assemblyName.Name}{extension}";
+            if (File.Exists(assemblyFileName))
+            {
+                return LoadFromFile(assemblyFileName);
+            }
+        }
+        // We cant find the assembly file, let the runtime try to handle it
+        return null;
+    }
+
+    private Assembly LoadFromFile(string assemblyFileName)
+    {
+        // It seems like LoadFromAssemblyPath lockes the file, and that makes our teste fail, so we load read the fine manually to a stream
+        var assemblyBytes = File.ReadAllBytes(assemblyFileName);
+        return LoadFromStream(new MemoryStream(assemblyBytes));
+    }
+}

--- a/src/develop/DryGen.Docs/Program.cs
+++ b/src/develop/DryGen.Docs/Program.cs
@@ -33,7 +33,7 @@ public static class Program
         GenerateExamplesFilesFromTemplates(rootDirectory);
         var result = 0;
         string assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        var generator = new Generator(Console.Out, Console.Error);
+        var generator = new Generator(Console.Out, Console.Error, useAssemblyLoadContextDefault: true);
         foreach (var generatorData in BuildExamplesGeneratorData())
         {
             result = ReplaceRepresentationInExample(rootDirectory, assemblyDirectory, generator, generatorData);


### PR DESCRIPTION
Isolated the loading of assemblies into a separate AssemblyLoadContext when generating mermaid diagrams from code, to prevent version clashes with our own dependencies