### PR TITLE
Generate entity names for generic types with - instead of ` in Mermaid ER diagrams

### DIFF
--- a/src/DryGen.MermaidFromCSharp/NamedType.cs
+++ b/src/DryGen.MermaidFromCSharp/NamedType.cs
@@ -9,7 +9,7 @@ public class NamedType : IDiagramType
 {
     public NamedType(string name, Type type)
     {
-        Name = name;
+        Name = name.Replace('`', '-');
         Type = type;
     }
 

--- a/src/develop/DryGen.UTests/Features/Mermaid/FromCSharpAndEfCore/ErDiagram/ByEfCore/GeneratingErEntities.feature
+++ b/src/develop/DryGen.UTests/Features/Mermaid/FromCSharpAndEfCore/ErDiagram/ByEfCore/GeneratingErEntities.feature
@@ -96,3 +96,32 @@ Scenario: Generates ER entities for an IEntity from inherited DBContext only onc
 			Customer
 		
 		"""
+
+Scenario: Generates ER entities for generic types with - in the name in stead of ~
+	#NB! We should probably generate a more meaningful name based on the type of the bound generic parameter instead of the internal class number (1 in this example)
+	Given this C# source code
+		"""
+		using Microsoft.EntityFrameworkCore;
+		namespace Test
+		{
+			public class PrimitiveDto<T> {
+				public T Value { get; set; }
+			}
+			public class TestDbContext: DbContext {
+				public TestDbContext(DbContextOptions options) : base(options) {}
+				protected override void OnModelCreating(ModelBuilder modelBuilder)
+				{
+					modelBuilder.Entity<PrimitiveDto<int>>().HasNoKey();
+				}
+			}
+		}
+		"""
+	When I generate an ER diagram using EF Core
+	Then I should get this generated representation
+		"""
+		erDiagram
+			PrimitiveDto-1 {
+				int Value
+			}
+		
+		"""


### PR DESCRIPTION
Generate entity names for generic types with - instead of ` in Mermaid ER diagrams, since ` is illegal in the Mermaid ER syntax